### PR TITLE
libcurl4-openssl-dev -> libcurl4-dev

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pkg_dependencies="build-essential cmake libssl-dev libcurl4-openssl-dev libxml2-dev libxslt-dev imagemagick ghostscript curl libmagickwand-dev git libpq-dev redis-server nodejs postgresql bison "
+pkg_dependencies="build-essential cmake libssl-dev libcurl4-dev libxml2-dev libxslt-dev imagemagick ghostscript curl libmagickwand-dev git libpq-dev redis-server nodejs postgresql bison "
 ruby_build_dependencies="bison libffi-dev libgdbm-dev libncurses5-dev libsqlite3-dev libyaml-dev pkg-config sqlite3 zlib1g-dev libgmp-dev libreadline-dev libssl-dev libjemalloc-dev"
 
 current_tag="v0.7.14.0"


### PR DESCRIPTION
We're trying to fix some weird cross-apps conflicts because of stupid dependency conflicts ... in particular various app require different versions of libcurl4-*-dev conflicting with each other, but it should be fine to just request libcurl4-dev