### PR TITLE
Fix permission at install

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Distributed social networking service
 - There is currently no LDAP integration
 - the installation is very long, especially the frontend building step
 - As upstream doesn't support it, there is no possibility to change the endpoint/url of diaspora\*. Please choose it carefully!
+- The main permission should be granted to "visitors". In other term, diaspora is intented to be a public application. Only deviate from that if you know what you are doing!
 
 ## Documentation and resources
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -22,6 +22,7 @@ Service de réseau social distribué
 - Il n'y a pas d'intégration LDAP pour le moment.
 - L'installation est très longue, en particulier l'étape de build du frontend.
 - le projet amont ne supporte pas les changements d'url, ainsi l'application yunohost ne supporte pas non plus cette action.
+- Le groupe visiteur doit avoir la permission "diaspora.main". En d'autres termes, diaspora est supposé être une application publique. Ne changez cela que si vous savez ce que vous faîtes ! 
 
 ## Documentations et ressources
 

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -1,3 +1,4 @@
 - There is currently no LDAP integration
 - the installation is very long, especially the frontend building step
 - As upstream doesn't support it, there is no possibility to change the endpoint/url of diaspora\*. Please choose it carefully!
+- The main permission should be granted to "visitors". In other term, diaspora is intented to be a public application. Only deviate from that if you know what you are doing!

--- a/doc/DISCLAIMER_fr.md
+++ b/doc/DISCLAIMER_fr.md
@@ -1,3 +1,4 @@
 - Il n'y a pas d'intégration LDAP pour le moment.
 - L'installation est très longue, en particulier l'étape de build du frontend.
 - le projet amont ne supporte pas les changements d'url, ainsi l'application yunohost ne supporte pas non plus cette action.
+- Le groupe visiteur doit avoir la permission "diaspora.main". En d'autres termes, diaspora est supposé être une application publique. Ne changez cela que si vous savez ce que vous faîtes ! 

--- a/scripts/install
+++ b/scripts/install
@@ -170,8 +170,7 @@ yunohost service add $app.target \
 #=================================================
 # SETUP SSOWAT
 #=================================================
-
-
+ynh_permission_update --permission "main" --add visitors
 
 #=================================================
 # CREATE AN ADMIN


### PR DESCRIPTION
Permission should be set to public (group visitors) for diaspora because it's not supposed to work in isolation.

It might work in a sort of private cloud, but it'll need some tests before trying it.