### PR TITLE
Add package_linter to github actions

### DIFF
--- a/.github/workflows/package_linter.yml
+++ b/.github/workflows/package_linter.yml
@@ -1,0 +1,41 @@
+name: YunoHost apps package linter
+
+on:
+  # Allow to manually trigger the workflow
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - testing
+  pull_request:
+  schedule:
+    - cron: '0 8 * * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install toml
+
+      - name: 'Clone YunoHost apps package linter'
+        run: |
+          git clone --depth=1 https://github.com/YunoHost/package_linter ~/package_linter
+
+      - name: 'Run linter'
+        run: |
+          ~/package_linter/package_linter.py . > linter_logs && cat linter_logs
+
+      - name: 'Analyze linter logs'
+        run: |
+          grep "Not even a warning\!" linter_logs
+


### PR DESCRIPTION
## Problem

- the level of this app changes without us knowing ;-)

## Solution

- Execute package_linter on MR, testing and master

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
