### PR TITLE
Switch to smtp method for sending mail, to have all the dkim,spf things

### DIFF
--- a/conf/diaspora.yml
+++ b/conf/diaspora.yml
@@ -557,7 +557,7 @@ configuration: ## Section
 
     ## This selects which mailer should be used. Use 'smtp' for a smtp
     ## connection or 'sendmail' to use the sendmail binary.
-    method: 'sendmail'
+    method: 'smtp'
 
     ## Ignore if method isn't 'smtp'.
     smtp: ## Section
@@ -565,36 +565,39 @@ configuration: ## Section
       ## Host and port of the smtp server handling outgoing mail.
       ## This should match the common name of the certificate sent by
       ## the SMTP server, if it sends one. (default port=587)
-      #host: 'smtp.example.org'
-      #port: 587
+      # we use localhost because I don't know an easy way to determine the main domain of an ynh instance
+      # it forces us to disable certificate verification below though...
+      host: 'localhost'
+      port: 25
 
       ## Authentication required to send mail (default='plain').
       ## Use one of 'plain', 'login' or 'cram_md5'. Use 'none'
       ## if server does not support authentication.
-      #authentication: 'plain'
+      authentication: 'plain'
 
       ## Credentials to log in to the SMTP server.
       ## May be necessary if authentication is not 'none'.
-      #username: 'change_me'
-      #password: 'change_me'
+      username: '__APP__'
+      password: '__MAIL_PWD__'
 
       ## Automatically enable TLS (default=true).
       ## Leave this commented out if authentication is set to 'none'.
       #starttls_auto: true
 
       ## The domain for the HELO command, if needed.
-      #domain: 'smtp.example.org'
+      domain: '__DOMAIN__'
 
       ## OpenSSL verify mode used when connecting to a SMTP server with TLS.
       ## Set this to 'none' if you have a self-signed certificate. Possible
       ## values: 'none', 'peer'.
-      #openssl_verify_mode: 'none'
+      # We use localhost because I don't 
+      openssl_verify_mode: 'none'
 
     ## Ignore if method isn't 'sendmail'
-    sendmail: ## Section
+    # sendmail: ## Section
 
       ## The path to the sendmail binary (default='/usr/sbin/sendmail')
-      location: '/usr/sbin/sendmail'
+      # location: '/usr/sbin/sendmail'
 
       ## Use exim and sendmail (default=false)
       #exim_fix: false

--- a/manifest.toml
+++ b/manifest.toml
@@ -53,6 +53,7 @@ ram.runtime = "2000M"
     autoupdate.strategy = "latest_github_release"
 
     [resources.system_user]
+    allow_email = true
 
     [resources.install_dir]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Diaspora"
 description.en = "Distributed social networking service"
 description.fr = "Service de réseau social distribué"
 
-version = "0.7.18.2~ynh2"
+version = "0.7.18.2~ynh3"
 
 maintainers = ["autra"]
 


### PR DESCRIPTION
## Problem

The sendmail method didn't set all the correct headers for mail not to go in spams.

## Solution

Follow the nextcloud example and send mail with the ynh smtp server.

Fixes #9


## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
