### PR TITLE
remove myself as maintainer

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -9,7 +9,7 @@ description.fr = "Service de réseau social distribué"
 
 version = "0.9.0.0~ynh3"
 
-maintainers = ["autra"]
+maintainers = []
 
 [upstream]
 license = "AGPL-3.0"


### PR DESCRIPTION
## Description

Removing myself as a maintainer. 

From my POV, each PR should wait for a maintainer review. However, that rule seems not to be applied. I prefer to remove myself from that list then, better that than having to ask each time so that people wait before merging :-)

It's a bit of a shame, if you ask me, because it means that small contributors haven't really their place in this community.

So long, and thanks for all the fish!
